### PR TITLE
Fix unbind error

### DIFF
--- a/lib/KendoWidgetMixin.js
+++ b/lib/KendoWidgetMixin.js
@@ -87,7 +87,7 @@ var KendoWidgetMixin = function (widget) {
         kendo.destroy(this.$widget);
       }
 
-      if (this.props.options.dataSource) {
+      if (this.props.options.dataSource && this.props.options.dataSource.unbind) {
         this.props.options.dataSource.unbind('change', this.$widget._refreshHandler);
         this.props.options.dataSource.unbind('error', this.$widget._errorHandler);
       }

--- a/lib/KendoWidgetMixin.js
+++ b/lib/KendoWidgetMixin.js
@@ -87,9 +87,9 @@ var KendoWidgetMixin = function (widget) {
         kendo.destroy(this.$widget);
       }
 
-      if (this.props.options.dataSource && this.props.options.dataSource.unbind) {
-        this.props.options.dataSource.unbind('change', this.$widget._refreshHandler);
-        this.props.options.dataSource.unbind('error', this.$widget._errorHandler);
+      if (this.$widget.dataSource) {
+        this.$widget.dataSource.unbind('change', this.$widget._refreshHandler);
+        this.$widget.dataSource.unbind('error', this.$widget._errorHandler);
       }
 
       if (this.props.debug) console.log('kendo widget unmounted:', widget);


### PR DESCRIPTION
Found a small issue with the latest version.  My datasource on props is just some properties, and doesn't have an unbind method.
