### PR TITLE
Add Template.wrap convenience function

### DIFF
--- a/lib/KendoTemplate.js
+++ b/lib/KendoTemplate.js
@@ -3,5 +3,10 @@ var ReactDOMServer = require('react-dom/server');
 var KendoTemplate = function (component) {
   return ReactDOMServer.renderToStaticMarkup(component);
 };
+KendoTemplate.wrap = function (component) {
+  return function (props) {
+    return KendoTemplate(component(props));
+  };
+};
 
 module.exports = KendoTemplate;


### PR DESCRIPTION
This just adds a wrapper function that makes wrapping simple components as kendo templates even easier.

Example:

``` javascript
var Kendo = = require('react-kendo');
var Scheduler = Kendo.Scheduler;
var Template = Kendo.Template;

var HoursHeader = function (props) {
  return <div>{props.date}</div>;
};

<Scheduler options={
  majorTimeHeaderTemplate: Template.wrap(HoursHeader)
} />
```

I apologize that the example is somewhat contrived. But for components that will take the same props as the Kendo template would take, `Template.wrap` will save some overhead.
